### PR TITLE
Modernize Python support and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,29 +13,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
-        include:
-          # Oldest supported version of main dependencies on Python 3.5.1
-          - os: ubuntu-latest
-            python-version: 3.5
-            OLDEST_SUPPORTED_VERSION: true
-            DEPENDENCIES: numpy==1.13.3 scipy==1.3.3
+        python-version: ['3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display versions
         run: python -V; pip -V
-      - name: Install oldest supported version
-        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
-        run: pip install ${{ matrix.DEPENDENCIES }}
-      - name: Install depedencies and package
+      - name: Install dependencies and package
         shell: bash
         run: pip install -U -e .'[tests]'
       - name: Run tests
-        run: pytest --cov=morphops --pyargs morphops
-      - name: Generate line coverage
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: coverage report --show-missing
+        if: ${{ matrix.os != 'ubuntu-latest' || matrix.python-version != '3.14' }}
+        run: pytest --pyargs morphops
+      - name: Run tests with coverage
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}
+        run: pytest --cov=morphops --cov-report=term-missing --pyargs morphops

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,17 @@ entries are sorted in descending chronological order.
 Unreleased
 ==========
 
+Changed
+-------
+- Dropped support for Python versions older than 3.12 and updated CI to test
+  Python 3.12 through 3.14.
+
+Fixed
+-----
+- Fixed compatibility with NumPy 2.x by replacing removed or deprecated NumPy
+  APIs.
+- Fixed invalid escape sequence warnings in math-heavy docstrings.
+
 Added
 -----
 - all-contributors section to README. Added manually due to `lack of rst support in the cli, bot <https://github.com/all-contributors/all-contributors-cli/issues/300>`_, but see `PR 301 there <https://github.com/all-contributors/all-contributors-cli/pull/301>`_.

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,13 @@ setup(
     packages=find_packages(),
     classifiers=[
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'License :: OSI Approved :: MIT License',
         'Topic :: Scientific/Engineering'
     ],
-    python_requires='>=3.5.1',
+    python_requires='>=3.12',
     extras_require=extra_feature_requirements,
     install_requires=['numpy >= 1.13.3', 'scipy >= 1.3.3'],
     include_package_data=True

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,16 @@
 [tox]
-envlist = py35,py36,python3.7
-
-[travis]
-python =
-  3.5: py35
-  3.6: py36
-  3.7: python3.7
-
-[testenv:py35]
-deps =
-  pytest
-  numpy==1.13.3
-  scipy==1.3.3
-commands =
-  pytest -q -s tests
-
-[testenv:py36]
-deps = 
-  pytest
-  pytest-cov
-  numpy==1.14.5
-  scipy==1.5.0
-commands = 
-  pytest -q -s tests
-  pytest --cov=morphops tests/
+envlist = py312,py313,py314-coverage
 
 [testenv]
 deps = 
   pytest
 commands = 
-  pytest -q -s tests
+  pytest -q -s --pyargs morphops
+
+[testenv:py314-coverage]
+basepython = python3.14
+deps =
+  pytest
+  pytest-cov
+commands =
+  pytest -q -s --cov=morphops --cov-report=term-missing --pyargs morphops


### PR DESCRIPTION
- Require Python 3.12 and test through Python 3.14
- Update GitHub Actions and tox configuration
- Keep coverage in one representative environment (now 3.14)
- Document the compatibility changes



#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
